### PR TITLE
Change version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Add tags to any azure subscription via terraform
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 0.5.0 |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 0.5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | ~> 0.5.0 |
+| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | >= 0.5.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 0.5.0"
+      version = ">= 0.5.0"
     }
   }
 }


### PR DESCRIPTION
# Description
According to [terraform documentation](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#terraform-core-and-provider-versions) the required provider version of public limits should only limit the minimum version.

The quite pessimistic version constraint ~>0.5.0 got replaced with >=0.5.0. This is required to allow other modules to use higher versions of the azapi provider. No other changes were implemented.

# Change overview (tick true):

- [ ] This introduces backward incompatible changes
- [ ] This adds a new backward compatible Feature
- [x] This fixes a Bug

# Version information: 

<!-- Look up the current/previous Version and update it below -->
- Previous Version: `2.0.0`
<!-- Update the version below, under which version you plan to release this PR. See Link on information how to increment the version number -->
- Next Version based on [Semantic Versioning](https://semver.org/#summary) (see above): `2.0.1`

# How Has This Been Tested?

- [x] Apply of all examples was successfull

# Checklist:

- [x] I have run tests and documented them above
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation

